### PR TITLE
Hotfix ErrorHandler log.

### DIFF
--- a/src/main/java/me/scolastico/tools/handler/ErrorHandler.java
+++ b/src/main/java/me/scolastico/tools/handler/ErrorHandler.java
@@ -51,9 +51,20 @@ public class ErrorHandler implements UncaughtExceptionHandler {
   public static void enableErrorLogFile() {
     try {
       errorLog = new File("error.log");
-      if (errorLog.exists() || errorLog.createNewFile()) {
+      if (errorLog.exists()) {
+        int counter = 2;
+        File destination = new File("error." + counter + ".log");
+        while (destination.exists()) {
+          counter++;
+          destination = new File("error." + counter + ".log");
+        }
+        FileUtils.copyFile(errorLog, destination);
+        FileUtils.writeStringToFile(errorLog, "Error log created at (UNIX) " + System.currentTimeMillis()/1000, StandardCharsets.UTF_8);
+      } else if (!errorLog.createNewFile()) {
         errorLog = null;
         throw new Exception("Cant create error.log file!");
+      } else {
+        FileUtils.writeStringToFile(errorLog, "Error log created at (UNIX) " + System.currentTimeMillis()/1000, StandardCharsets.UTF_8);
       }
     } catch (Exception e) {
       handle(e);

--- a/src/main/java/me/scolastico/tools/simplified/SimplifiedResourceFileReader.java
+++ b/src/main/java/me/scolastico/tools/simplified/SimplifiedResourceFileReader.java
@@ -5,10 +5,17 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 
+/**
+ * Simple functions to read a byte array or a string out of a file in the resources.
+ */
 public class SimplifiedResourceFileReader {
 
   private static SimplifiedResourceFileReader instance = null;
 
+  /**
+   * Get the instance. This class is a singleton.
+   * @return The instance.
+   */
   public static SimplifiedResourceFileReader getInstance() {
     if (instance == null) {
       instance = new SimplifiedResourceFileReader();


### PR DESCRIPTION
### **Describe the pull request**
The error handler throws an error if you try to enable error logging in files if the error file is allready existing. This is fixed with this pr. Also updated the java docs for the SimplifiedResourceFileReader.

### **Is this referenced to a issue?**
no

### **Additional context**
no